### PR TITLE
fixed quotes in curl command for identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Get your identity list by using curl with JMAP HTTP headers (explained above) an
 curl \
 --header 'Content-Type: application/json; charset=utf-8' \
 --header 'Accept: application/json' \
---header 'Authorization: Bearer $token" \
+--header 'Authorization: Bearer '"$token"'' \
 --request POST \
 --data '
 {


### PR DESCRIPTION
Command didn't work, because $token was not expanded correctly due to missing quotes (GNU bash, version 5.1.16(1)-release)